### PR TITLE
adds support for click extensions on osx arm

### DIFF
--- a/Desktop.Robot/Clicks/Clicks.cs
+++ b/Desktop.Robot/Clicks/Clicks.cs
@@ -24,7 +24,9 @@ namespace Desktop.Robot.Clicks
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return new OSX.RightClick(delay);
+                return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 
+                    ? new OSX.ARM.RightClick(delay) 
+                    : new OSX.RightClick(delay);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -44,7 +46,9 @@ namespace Desktop.Robot.Clicks
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return new OSX.LeftClick(delay);
+                return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 
+                    ? new OSX.ARM.LeftClick(delay) 
+                    : new OSX.LeftClick(delay);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -64,7 +68,9 @@ namespace Desktop.Robot.Clicks
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return new OSX.MiddleClick(delay);
+                return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 
+                    ? new OSX.ARM.MiddleClick(delay) 
+                    : new OSX.MiddleClick(delay);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/Desktop.Robot/Clicks/OSX/ARM/Common.cs
+++ b/Desktop.Robot/Clicks/OSX/ARM/Common.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Desktop.Robot.Clicks.OSX.ARM
+{
+    static class Common
+    {
+        [DllImport("./osx_arm.os", EntryPoint = "rightMouseUp")]
+        internal static extern void RightClickUp(uint x, uint y);
+
+        [DllImport("./osx_arm.os", EntryPoint = "rightMouseDown")]
+        internal static extern void RightClickDown(uint x, uint y);
+
+
+        [DllImport("./osx_arm.os", EntryPoint = "leftMouseUp")]
+        internal static extern void LeftClickUp(uint x, uint y);
+
+        [DllImport("./osx_arm.os", EntryPoint = "leftMouseDown")]
+        internal static extern void LeftClickDown(uint x, uint y);
+
+
+        [DllImport("./osx_arm.os", EntryPoint = "otherMouseUp")]
+        internal static extern void OtherClickUp(uint x, uint y);
+
+        [DllImport("./osx_arm.os", EntryPoint = "otherMouseDown")]
+        internal static extern void OtherClickDown(uint x, uint y);
+    }
+}

--- a/Desktop.Robot/Clicks/OSX/ARM/LeftClick.cs
+++ b/Desktop.Robot/Clicks/OSX/ARM/LeftClick.cs
@@ -1,0 +1,17 @@
+﻿namespace Desktop.Robot.Clicks.OSX.ARM
+{
+    internal record LeftClick(int delay) : IClick
+    {
+        public int Delay => delay;
+
+        public void ExecuteMouseDown(MouseContext context)
+        {
+            Common.LeftClickDown((uint)context.Position.X, (uint)context.Position.Y);
+        }
+
+        public void ExecuteMouseUp(MouseContext context)
+        {
+            Common.LeftClickUp((uint)context.Position.X, (uint)context.Position.Y);
+        }
+    }
+}

--- a/Desktop.Robot/Clicks/OSX/ARM/MiddleClick.cs
+++ b/Desktop.Robot/Clicks/OSX/ARM/MiddleClick.cs
@@ -1,0 +1,17 @@
+﻿namespace Desktop.Robot.Clicks.OSX.ARM
+{
+    internal record MiddleClick(int delay) : IClick
+    {
+        public int Delay => delay;
+
+        public void ExecuteMouseDown(MouseContext context)
+        {
+            Common.OtherClickDown((uint)context.Position.X, (uint)context.Position.Y);
+        }
+
+        public void ExecuteMouseUp(MouseContext context)
+        {
+            Common.OtherClickUp((uint)context.Position.X, (uint)context.Position.Y);
+        }
+    }
+}

--- a/Desktop.Robot/Clicks/OSX/ARM/RightClick.cs
+++ b/Desktop.Robot/Clicks/OSX/ARM/RightClick.cs
@@ -1,0 +1,17 @@
+﻿namespace Desktop.Robot.Clicks.OSX.ARM
+{
+    internal record RightClick(int delay) : IClick
+    {
+        public int Delay => delay;
+
+        public void ExecuteMouseDown(MouseContext context)
+        {
+            Common.RightClickDown((uint)context.Position.X, (uint)context.Position.Y);
+        }
+
+        public void ExecuteMouseUp(MouseContext context)
+        {
+            Common.RightClickUp((uint)context.Position.X, (uint)context.Position.Y);
+        }
+    }
+}


### PR DESCRIPTION
Hey, I noticed that the lovely click extension methods weren't working on my ARM based mac laptop. It was throwing an error about trying to load the wrong architecture file, and I noticed that there was no branching logic for the ARM vs not-ARM in the click extensions. 

I tried to follow some convention, and I did a little ternary switch in the extension method to send ARM based OSX stuff to a new namespace, that is an exact copy of the old OSX click stuff; except it uses the already existing osx_arm.so file.